### PR TITLE
JSの気になる点を修正

### DIFF
--- a/modal.js
+++ b/modal.js
@@ -1,17 +1,19 @@
 $(function(){
 
-// モーダルウィンドウが開くときの処理	
-$(".modalopen").click(function(){
-        $(".modal").fadeIn();
-	$(this).addClass("open");
-	return false;
-});
+  var $modal = $(".modal");
+  var $modalOpen = $(".modalopen");
+  var $modalClose = $(".modalclose");
 
-// モーダルウィンドウが閉じるときの処理	
-$(".modalclose").click(function(){
-	$(this).parents(".modal").fadeOut();
-	$(".modalopen").removeClass("open");
-	return false;
-});  
-    
+  // モーダルウィンドウが開くときの処理
+  $modalOpen.click(function(){
+    $modal.fadeIn();
+    return false;
+  });
+
+  // モーダルウィンドウが閉じるときの処理
+  $modalClose.click(function(){
+    $modal.fadeOut();
+    return false;
+  });
+
 });


### PR DESCRIPTION
以下の点を修正しましたので、ご確認ください。

- スペースとタブの混同
- 空行や末尾の不要なスペースを削除
-  $(".modalopen")などの何度も利用するセレクタは変数に格納（$(".modalclose")は一回しか利用していないので、変数に入れるかどうかは自由ですが、統一感のために変数に格納しています）。
- $(".modalopen")にopenクラスを着脱をしているが、スタイルの変更に関与しているわけでもないようなので削除（もし、着脱の意図があればお手数ですが説明していただけますか）。
- $(this).parents(".modal")でセレクタを指定しなくても良いと思うため$modal に変更（もし、parentsの意図があればお手数ですが説明していただけますか）。